### PR TITLE
Shrink spacers in settings button panel.

### DIFF
--- a/res/layout/settings_pane.xml
+++ b/res/layout/settings_pane.xml
@@ -37,7 +37,7 @@
                 <Space
                     android:layout_width="0dip"
                     android:layout_height="1dp"
-                    android:layout_weight="1" />
+                    android:layout_weight="0.5" />
 
                 <TextView
                     android:id="@+id/wallpaper_button"
@@ -57,7 +57,7 @@
                 <Space
                     android:layout_width="0dip"
                     android:layout_height="1dp"
-                    android:layout_weight="1" />
+                    android:layout_weight="0.5" />
 
                 <TextView
                     android:id="@+id/widget_button"
@@ -77,7 +77,7 @@
                 <Space
                     android:layout_width="0dip"
                     android:layout_height="1dp"
-                    android:layout_weight="1" />
+                    android:layout_weight="0.5" />
 
                 <TextView
                     android:id="@+id/settings_button"
@@ -97,7 +97,7 @@
                 <Space
                     android:layout_width="0dip"
                     android:layout_height="1dp"
-                    android:layout_weight="1" />
+                    android:layout_weight="0.5" />
 
             </LinearLayout>
         </LinearLayout>


### PR DESCRIPTION
Previously there was not enough space for the button labels in some
languages (e.g. German).

Change-Id: I086908c0777e996ef37b0a3a4ea919f2d1c3f4cc